### PR TITLE
Added molecule player progress bar

### DIFF
--- a/src/components/atoms/songBar/index.css
+++ b/src/components/atoms/songBar/index.css
@@ -1,16 +1,13 @@
 input[type='range'] {
+  border-radius: 2px;
+  height: 3px;
   -webkit-appearance: none;
   appearance: none;
-  height: 3px;
-  border-radius: 2px;
-}
-input[type='range']::-ms-track {
-  background: transparent;
 }
 input[type='range']::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  background: #ff2626;
-  height: 10px;
   width: 10px;
+  -webkit-appearance: none;
+  height: 10px;
+  background-color: #ff2626;
   border-radius: 25px;
 }

--- a/src/components/atoms/songBar/index.tsx
+++ b/src/components/atoms/songBar/index.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, ChangeEventHandler, FC } from 'react';
 
 import './index.css';
+import theme from '../../../theme/theme';
 
 type SongBarTypes = {
   value: number;
@@ -17,7 +18,7 @@ const SongBar: FC<SongBarTypes> = (props) => {
       min={0}
       max={props?.duration}
       step={1}
-      style={props?.style}
+      style={{...props?.style, background: `linear-gradient(to right, ${theme.palette.secondary.main} 0%, ${theme.palette.secondary.main} ${props?.value/props?.duration*100}%, ${theme.palette.text.primary} ${props?.value/props?.duration*100}%, ${theme.palette.text.primary} 100%)`}}
       onChange={props?.onChange}
     />
   );

--- a/src/components/molecules/controlButtons/index.tsx
+++ b/src/components/molecules/controlButtons/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import styled from '@emotion/styled';
+import { styled } from '@mui/material/styles';
 import { Box } from '@mui/material';
 
 import Icon from '../../atoms/icon';
@@ -9,14 +9,14 @@ import previousIcon from '../../../assets/images/previous.svg';
 import nextIcon from '../../../assets/images/next.svg';
 import shuffleIcon from '../../../assets/images/shuffle.svg';
 
-const ButtonBox = styled(Box)(() => ({
+const ButtonBox = styled(Box)({
     backgroundColor: theme.palette.primary["500"],
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
     flexGrow: 1,
-}));
+});
 
 const genericIconStyles = {
     width: '32px',

--- a/src/components/molecules/footer/index.tsx
+++ b/src/components/molecules/footer/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Grid } from '@mui/material';
-import styled from '@emotion/styled';
+import { styled } from '@mui/material/styles';
 
 import Typography from '../../atoms/typography';
 import theme from '../../../theme/theme';
@@ -11,15 +11,15 @@ import {
   footerSubText,
 } from '../../../utils/constants';
 
-const FooterBox = styled(Box)(() => ({
+const FooterBox = styled(Box)({
   backgroundColor: theme.palette.primary.main,
   padding: `${theme.spacing(2)} ${theme.spacing(0)} ${theme.spacing(4)} ${theme.spacing(0)}`,
   flexGrow: 1,
-}));
+});
 
-const GridLeftItem = styled(Grid)(() => ({
+const GridLeftItem = styled(Grid)({
   height: '100%',
-}));
+});
 
 const Footer = () => {
   return (

--- a/src/components/molecules/playerProgressBar/index.tsx
+++ b/src/components/molecules/playerProgressBar/index.tsx
@@ -1,0 +1,59 @@
+import React, { ChangeEventHandler, FC } from 'react';
+import Box from '@mui/material/Box/Box';
+import { styled } from '@mui/material/styles';
+
+import Typography from '../../atoms/typography';
+import theme from '../../../theme/theme';
+import SongBar from '../../atoms/songBar';
+import '../../atoms/songBar/index.css';
+
+type PlayerProgressBarProps = {
+  value: number;
+  duration: number;
+  remainingDuration: string;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  songName: string;
+  artistName: string;
+};
+
+const StyledBox = styled(Box)({
+  marginTop: `${theme.spacing(4)}`,
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
+});
+
+const StyledContainer = styled(Box)({
+  backgroundColor: theme.palette.primary['500'],
+  padding: `${theme.spacing(3)} ${theme.spacing(0)}`,
+});
+
+const songBarStyles = {
+  marginBottom: `${theme.spacing(2)}`
+}
+
+const PlayerProgressBar: FC<PlayerProgressBarProps> = (props) => {
+  return (
+    <StyledContainer>
+      <Typography variant='h3' color={theme.palette.text.secondary}>
+        {props?.songName}
+      </Typography>
+      <Typography variant='body3' color={theme.palette.text.primary}>
+        {props?.artistName}
+      </Typography>
+      <StyledBox>
+        <SongBar
+          value={props?.value}
+          duration={props?.duration}
+          onChange={props?.onChange}
+          style={songBarStyles}
+        />
+        <Typography variant='subtitle3' color={theme.palette.text.primary}>
+          {props?.remainingDuration}
+        </Typography>
+      </StyledBox>
+    </StyledContainer>
+  );
+};
+
+export default PlayerProgressBar;


### PR DESCRIPTION
Implemented Player Progress Bar molecule that accepts `value`, `duration`, `remainingDuration`, `songName`, `artistName` and  `onChange` properties. It uses `SongBar` atom for rendering the current song time bar.

Updated SongBar component styles to display `#ff2626` color for the filled range.

Updated `styled` import from material UI.